### PR TITLE
docs: bring CLAUDE.md in line with the current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,32 +4,84 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Commands
 
-- `pnpm dev` - Start development server
-- `pnpm build` - Build the application for production
-- `pnpm export` - Copy extra files to out directory (used after build)
-- `pnpm type-check` - Run TypeScript type checking without emitting files
-- `pnpm deploy` - Deploy to GitHub Pages using gh-pages
+- `pnpm dev` — Start the development server
+- `pnpm build` — Production build (static export into `out/`)
+- `pnpm export` — Copy `extra/` into `out/`; run *after* `pnpm build`, not instead of it
+- `pnpm lint` / `pnpm lint:fix` — Run oxlint
+- `pnpm type-check` — `tsc --noEmit`
+- `pnpm deploy` — Manual gh-pages publish (see Deployment — this differs from CI)
 
-## Project Architecture
+There is no test framework in this repo. CI runs `pnpm lint` and `pnpm build` only.
 
-This is a Next.js-based portfolio site with AMP (Accelerated Mobile Pages) support. The project uses a component-based architecture following atomic design principles:
+## AMP is the central constraint
 
-### Component Structure
-- **Atoms** (`components/atoms/`): Basic UI elements (Avatar, Heading, Icon, Paragraph)
-- **Templates** (`components/templates/`): Page layout components
-- **Head** (`head/`): Meta tags and head elements
+`pages/index.tsx` sets `export const config = { amp: true }`. Almost every non-obvious
+decision in this codebase follows from that, so check it before proposing changes:
 
-### Key Technical Details
-- **AMP Support**: The main page (`pages/index.tsx`) is AMP-enabled with `export const config = { amp: true }`
-- **Static Export**: Configured for static site generation with `output: "export"` in next.config.js
-- **Styling**: Uses inline styles and Font Awesome icons, not styled-components despite it being in dependencies
-- **TypeScript**: Configured with loose settings (`strict: false`)
+- **No client-side JS.** AMP forbids custom scripts, which is why there is no CSS-in-JS
+  runtime, no icon library that ships JS, and no interactive components.
+- **No `next/image`.** It cannot render in AMP, and `output: "export"` provides no image
+  loader. `components/atoms/Avatar.tsx` branches on the `isAmp` prop instead, emitting
+  `<amp-img>` via `React.createElement` (JSX would not typecheck cleanly) or a plain
+  `<img>`.
+- **`<amp-img>` is hand-declared.** `index.d.ts` augments the global `JSX.IntrinsicElements`
+  namespace. New AMP elements need an entry there.
+- **Next.js 16 removed AMP support.** `next/amp` no longer exists, so the framework cannot
+  be upgraded past 15 without first migrating off AMP. A Dependabot PR attempting this
+  fails to compile on `import { useAmp } from "next/amp"`.
 
-### Component Patterns
-- Components use inline TypeScript prop definitions
-- AMP-aware components check `useAmp()` hook to render appropriate elements
-- Styling is primarily done through inline style objects
-- Font Awesome classes used for icons (`fa fa-${name}`)
+## Architecture
 
-### Deployment
-The site deploys to GitHub Pages using the `deploy` script which uses gh-pages to deploy the `out` directory to the `master` branch.
+Atomic-design layout: `components/atoms/` (Avatar, Heading, Icon, Paragraph),
+`components/templates/` (Page), `head/` (Meta). Each directory has a barrel `index.ts`;
+import through it rather than reaching for the file directly.
+
+Styling is **inline style objects only** — there is no stylesheet, no CSS module, and no
+CSS-in-JS dependency. `Page.tsx` holds the layout container style; everything else styles
+at the call site. Global `body` styling is injected as a raw `<style>` tag from
+`pages/_document.tsx`'s `getInitialProps`.
+
+Two external stylesheets are loaded by `<link>` from `head/Meta.tsx`, not from npm:
+
+- **Font Awesome 4.7.0** off `maxcdn.bootstrapcdn.com`. `components/atoms/Icon.tsx` renders
+  icons purely as `fa fa-${name}` class names, so the whole icon set depends on this CDN.
+- **Google Fonts (Source Sans Pro)**, referenced by `fontFamily` in `Page.tsx` and
+  `_document.tsx`.
+
+`head/Meta.tsx` is rendered from inside the page rather than from `_document.tsx`, and
+carries the full SEO/OG/Twitter card set.
+
+TypeScript runs with `strict: false`.
+
+## Linting
+
+oxlint is configured in `.oxlintrc.json` with the typescript, unicorn, oxc, react, nextjs,
+jsx-a11y and import plugins; `correctness`, `suspicious` and `perf` run as errors.
+
+Three rules are deliberately off, each with a comment in the config explaining why. Do not
+re-enable them without addressing the underlying constraint: `react/react-in-jsx-scope`
+(automatic JSX runtime), `nextjs/no-img-element` and `nextjs/no-page-custom-font` (both AMP
+consequences described above).
+
+## Deployment
+
+**Pushing to `master` deploys to production.** `.github/workflows/Deploy.yml` triggers on
+push to `master`, builds, runs `pnpm export`, then publishes `out/` with `npx gh-pages`.
+It re-points `origin` at the current repo first, so it lands on the `gh-pages` branch of
+`naturalclar.dev`. The workflow is guarded by `if: github.repository ==
+'Naturalclar/naturalclar.dev'` so forks do not deploy.
+
+The `pnpm deploy` script does something different: `gh-pages -d out -o gh-pages -b master`
+targets the remote named `gh-pages` (the separate `naturalclar.github.io` repo) and the
+`master` branch there. Do not assume the two paths are interchangeable.
+
+## Gotchas
+
+- `tsconfig.tsbuildinfo` is **tracked in git**, so `pnpm type-check` and `pnpm build` dirty
+  the working tree. Restore it before committing unless the change is intentional.
+- `pnpm build` fails at the AMP validation step in sandboxes without network access — the
+  AMP Optimizer cannot fetch the runtime version from `cdn.ampproject.org` and emits
+  `style[amp-runtime]` without `i-amphtml-version`. This is environmental, not a code
+  defect; compare against an unmodified checkout before investigating.
+- CI pins pnpm 9 while the lockfile is `lockfileVersion: '9.0'`; pnpm 10 writes the same
+  version, so regenerating locally with pnpm 10 stays compatible with `--frozen-lockfile`.


### PR DESCRIPTION
## What

Rewrites `CLAUDE.md`. Documentation only — no code, config, or workflow changes.

## Why

The guidance had drifted from the code, in two ways that would actively mislead:

- It described `styled-components` as a dependency that exists but goes unused. It was removed in #45.
- It presented `pnpm deploy` as the deployment path. Pushing to `master` is what actually deploys, via `.github/workflows/Deploy.yml`.

## What's added

Beyond the corrections, this fills in the context that currently takes several files to reconstruct.

**AMP as the organising constraint.** Most of the non-obvious decisions in this repo trace back to `export const config = { amp: true }` in `pages/index.tsx`, but that connection was never written down. Now collected in one place: why there is no CSS-in-JS runtime, why `next/image` is unusable (no loader under `output: "export"`, and it cannot render in AMP), why `Avatar.tsx` reaches for `React.createElement('amp-img', ...)` instead of JSX, and why `index.d.ts` augments `JSX.IntrinsicElements` by hand.

It also records that **Next.js 16 removed `next/amp`**, which is why the framework cannot move past 15 without migrating off AMP first. This is the root cause of the failing Dependabot PR #40, and it is not obvious from any single file.

**The two deployment paths differ.** The Deploy workflow re-points `origin` at this repo and publishes `out/` to its `gh-pages` branch. The `pnpm deploy` script uses `-o gh-pages -b master`, targeting the `master` branch of the separate `naturalclar.github.io` repo. Easy to conflate; now spelled out.

**Linting.** The oxlint setup from #46, and why three rules are deliberately disabled, so they do not get re-enabled without addressing the underlying AMP constraint.

**Gotchas.**

- `tsconfig.tsbuildinfo` is tracked in git, so `type-check` and `build` dirty the working tree.
- `pnpm build` fails at AMP validation in sandboxes without network access — the AMP Optimizer cannot reach `cdn.ampproject.org`. Environmental, not a code defect; worth knowing before investigating.
- pnpm 9 (CI) and pnpm 10 both write `lockfileVersion: '9.0'`, so regenerating locally stays compatible with `--frozen-lockfile`.

Finally, it states plainly that there is no test framework, rather than leaving that ambiguous.

## Note

`README.md` is also out of date — it says "Next.js 14 with AMP support" (the repo is on 15) and its script list predates `pnpm lint`. Not touched here to keep this diff to a single file; happy to follow up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_