### PR TITLE
ci: run type-check as its own step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Type check
+        run: pnpm type-check
+
       - name: Test Build
         run: pnpm build


### PR DESCRIPTION
Closes #44

## What

Adds a `Type check` step to `.github/workflows/CI.yml`, between `Lint` and `Test Build`:

```yaml
- name: Type check
  run: pnpm type-check
```

One file changed, three lines added.

## Correcting the issue's rationale

#44 claimed the step would widen coverage, on the reasoning that `tsconfig.json` includes `**/*.ts` and `**/*.tsx` while `next build` only reaches files in the module graph of a page. **That premise is wrong**, and it seemed worth checking rather than repeating.

Test: a file no page imports, with a deliberate type error.

```ts
// orphan-check.ts
export const bad: number = "not a number";
```

`pnpm build` rejects it:

```
./orphan-check.ts:1:14
Type error: Type 'string' is not assignable to type 'number'.
```

So Next.js type-checks the full tsconfig include set, and the separate step adds no coverage that the build did not already have.

## Why keep it anyway

Two reasons that do hold up:

- **Faster failure.** `pnpm type-check` completes in ~2.4s locally; `pnpm build` takes ~15s. Ordering the cheap checks first means a type error stops CI sooner.
- **Unambiguous signal.** A type error surfaces as a failed `Type check` step rather than a failed `Test Build`, which in this repo can also fail for AMP validation reasons unrelated to types.

If neither justifies the extra step, this PR is fine to close — the build already enforces the constraint.

## Verification

The acceptance criterion on #44 is that CI fails when a type error is introduced. Confirmed directly, with the repo's committed `tsconfig.tsbuildinfo` in place, since `incremental: true` could in principle let a stale cache mask a fresh error:

```
components/atoms/Heading.tsx(30,7): error TS2322: Type 'string' is not assignable to type 'number'.
ELIFECYCLE  Command failed with exit code 2
```

It does not mask it. On the clean tree, `pnpm lint`, `pnpm type-check`, and `pnpm build` (compile and static generation) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_