### PR TITLE
ci: move workflows from Node.js 20 to 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      node-version: 20.x
+      node-version: 24.x
 
     steps:
       - name: Checkout code

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'Naturalclar/naturalclar.dev'
 
     env:
-      node-version: 20.x
+      node-version: 24.x
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #49

## What

Bumps `node-version` from `20.x` to `24.x` in both workflows. One line each.

- `.github/workflows/CI.yml`
- `.github/workflows/Deploy.yml`

## Why

Node.js 20 (Iron) reached end-of-life on **2026-04-30** and no longer receives security patches. `Deploy.yml` builds and publishes the live site, so production builds were running on an unsupported runtime.

Per the [official release schedule](https://github.com/nodejs/Release/blob/main/schedule.json):

| Version | Codename | Status | End-of-life |
|---|---|---|---|
| 20 | Iron | **End-of-life** | 2026-04-30 |
| 22 | Jod | Maintenance | 2027-04-30 |
| **24** | Krypton | **Active LTS** | 2028-04-30 |

`22.x` was the more conservative option, but it is already in maintenance and goes EOL in April 2027, so it would need revisiting sooner. `24.x` is the current Active LTS.

## Verification

Rather than infer compatibility from `engines` ranges, this was run against a real Node 24 toolchain — Node **24.19.0** with **pnpm 9**, matching what `actions/setup-node` and `pnpm/action-setup` provision in the workflows.

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | pass |
| `pnpm lint` | pass |
| `pnpm type-check` | pass |
| `pnpm build` — compile + static generation | pass (`✓ Compiled successfully`, `✓ Generating static pages (3/3)`) |

The build still exits non-zero at the AMP validation step, because the AMP Optimizer cannot reach `cdn.ampproject.org` without network access. That behaviour is identical under Node 22 and unrelated to this change; CI has network access and passes there.

## Not included

#49 also listed two optional follow-ups, deliberately left out to keep this diff to the version bump:

- an `engines` field in `package.json` — nothing currently declares the supported Node range
- `.nvmrc` / `.node-version` so local development tracks CI

Happy to add either if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_