### PR TITLE
ci: move from pnpm 9 to 11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "author": "Jesse Katsumata <jesse.katsumata@gmail.com>",
   "main": "index.js",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "build": "next build",
     "deploy": "gh-pages -d out -o gh-pages -b master",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# sharp arrives transitively via Next.js and is only needed by next/image,
+# which this project cannot use: the page is AMP and the build is a static
+# export with no image loader. Denying its install scripts keeps them from
+# running without losing anything.
+allowBuilds:
+  sharp: false


### PR DESCRIPTION
Closes #52

## What

| File | Change |
|---|---|
| `package.json` | adds `"packageManager": "pnpm@11.21.0"` |
| `.github/workflows/CI.yml` | drops the `version: 9` input |
| `.github/workflows/Deploy.yml` | drops the `version: 9` input |
| `pnpm-workspace.yaml` | **new** — denies `sharp` build scripts |

`pnpm-lock.yaml` is untouched. See below.

## `packageManager` as the single source of truth

Rather than bumping `version: 9` to `version: 11`, the version now lives only in `package.json`. [action-setup's README](https://github.com/pnpm/action-setup/tree/v4) documents `version` as:

> **Optional** when there is a `packageManager` field in the `package.json`. otherwise, this field is **required**

What happens when *both* are set is not documented, so this sets only one. It also fixes the underlying problem #52 described: nothing pinned pnpm for local development, which is how the drift from CI went unnoticed. Corepack now picks up the same version locally.

## The sharp decision

pnpm 10 turned unapproved build scripts from a warning into an error. Under pnpm 11 this repo fails at install:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.2
```

`sharp` is **denied**, recorded in `pnpm-workspace.yaml`:

```yaml
allowBuilds:
  sharp: false
```

It arrives transitively through Next.js and exists to serve `next/image`, which this project cannot use — the page is AMP and the build is a static export with no image loader. Nothing in the source imports it; the only reference anywhere is the generated `next-env.d.ts` type include. Denying means its install scripts do not run, and the build still passes (verified below).

Worth recording for whoever touches this next: **this setting is only read from `pnpm-workspace.yaml`.** A `pnpm.allowBuilds` key in `package.json` is silently ignored — I tried that first to avoid adding a file to a single-package repo, and the install failed identically while pnpm recreated `pnpm-workspace.yaml` on its own.

## Verification

Run against a real Node 24.19.0 + pnpm 11.21.0 toolchain, matching what the workflows now provision:

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | pass, no build-script error |
| `pnpm lint` | pass |
| `pnpm type-check` | pass |
| `pnpm build` — compile + static generation | pass |

**The lockfile needs no regeneration.** #52 flagged this as unverified; pnpm 11 leaves `pnpm-lock.yaml` byte-identical at `lockfileVersion: '9.0'`, confirmed by a clean `git status` after install.

As on previous PRs, the build still exits non-zero at AMP validation in a sandbox without network access — the AMP Optimizer cannot reach `cdn.ampproject.org`. Unrelated to this change and identical on `master`.

## Risk

`Deploy.yml` is affected, so a mistake here breaks publishing rather than just CI. The change is verifiable locally except for one thing: whether `action-setup` resolves the version from `packageManager` on the runner. That is its documented behaviour, and CI on this PR exercises the exact same step, so a green CI run confirms it before anything reaches `master`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_