### PR TITLE
ci: update GitHub Actions off the deprecated node20 runtime

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.node-version }}
           cache: 'pnpm'


### PR DESCRIPTION
Closes #55

## What

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `pnpm/action-setup` | v4 | **v6** |

Applied to both `CI.yml` and `Deploy.yml`. Six lines.

## Why

All three were built against the Node 20 action runtime, which GitHub deprecated and is currently force-running on Node 24 — hence the warning closing every run:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4,
pnpm/action-setup@v4.
```

## Breaking-change review

These are two-to-three major bumps, so the release notes were read rather than the tags just swapped. Nothing here affects these workflows:

**actions/checkout**
- v5 — node24 runtime (the point of this PR).
- v6 — `persist-credentials` now writes to `$RUNNER_TEMP` instead of `.git/config`. This was the flagged risk for `Deploy.yml`, but that job sets its own token URL on `origin` before publishing, so it never depended on the persisted credentials. Upstream also states no workflow changes are required.
- v7 — refuses fork PR checkout under `pull_request_target` / `workflow_run`. Both workflows trigger on `push`, so this does not apply. Also an ESM migration.
- Behaviour with no inputs is unchanged.

**actions/setup-node**
- v5 — caching on by default *when no `cache` input is given*. Both workflows pass `cache: 'pnpm'` explicitly, so nothing changes.
- v6 — removes `always-auth` (unused here). Its automatic npm caching triggers on a `packageManager` field naming **npm**; ours names pnpm.
- v7 — ESM migration.
- `node-version` and `cache: pnpm` are both still supported.

**pnpm/action-setup**
- v6 still documents `version` as "**Optional** when there is a `packageManager` or `devEngines.packageManager` field in the `package.json`", which is the arrangement #53 established.

Runner requirements (v2.327.1+ for checkout v5, v2.329.0+ for authenticated git from container actions) are satisfied by GitHub-hosted `ubuntu-latest`.

## Verification

Action versions cannot be exercised locally, so CI on this PR is the check — it runs the same `checkout` → `action-setup` → `setup-node` → install sequence. A green run also confirms `pnpm/action-setup@v6` still resolves the version from `packageManager`.

**`Deploy.yml` needs a look after merge, not just before.** Its `gh-pages` publish step only runs on push to `master`, so CI here does not exercise it. I will check that run once this lands.

## Noted for later

`pnpm/action-setup`'s README now points at a newer `pnpm/setup` action as the successor. Switching is a larger change than a version bump and is out of scope here, but it is worth tracking separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_