### PR TITLE
docs: bring README.md in line with the current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ This is a minimalist portfolio site showcasing:
 
 ## Tech Stack
 
-- **Framework**: Next.js 14 with AMP support
+- **Framework**: Next.js 15 with AMP support
 - **Language**: TypeScript
 - **Styling**: Inline styles with Font Awesome icons
+- **Linting**: oxlint
 - **Deployment**: GitHub Pages via static export
 - **Package Manager**: pnpm
 
@@ -22,8 +23,9 @@ This is a minimalist portfolio site showcasing:
 
 ### Prerequisites
 
-- Node.js
-- pnpm
+- Node.js — CI runs 24.x
+- pnpm — the version is pinned by the `packageManager` field in `package.json`, so
+  [Corepack](https://nodejs.org/api/corepack.html) will select it for you
 
 ### Getting Started
 
@@ -41,9 +43,11 @@ Visit [http://localhost:3000](http://localhost:3000) to view the site.
 
 - `pnpm dev` - Start development server
 - `pnpm build` - Build for production
-- `pnpm export` - Copy additional files to output directory
+- `pnpm export` - Copy additional files to output directory (run *after* `pnpm build`)
+- `pnpm lint` - Run oxlint
+- `pnpm lint:fix` - Run oxlint and apply fixes
 - `pnpm type-check` - Run TypeScript type checking
-- `pnpm deploy` - Deploy to GitHub Pages
+- `pnpm deploy` - Manual gh-pages publish (see Deployment — this is not how CI deploys)
 
 ## Project Structure
 
@@ -63,7 +67,9 @@ Visit [http://localhost:3000](http://localhost:3000) to view the site.
 │   └── index.tsx       # Main page (AMP-enabled)
 ├── public/
 │   └── static/         # Static assets
-└── extra/              # Additional files for deployment
+├── extra/              # Additional files copied into out/ at deploy time
+├── index.d.ts          # JSX declarations for AMP elements (<amp-img>)
+└── .oxlintrc.json      # Lint configuration
 ```
 
 ## Features
@@ -76,13 +82,18 @@ Visit [http://localhost:3000](http://localhost:3000) to view the site.
 
 ## Deployment
 
-The site is deployed to GitHub Pages using the following process:
+**Pushing to `master` deploys the site.** `.github/workflows/Deploy.yml` runs on every push
+to `master`: it builds, runs `pnpm export`, and publishes `out/` with `gh-pages`. It points
+`origin` at this repository first, so the result lands on the `gh-pages` branch of
+`naturalclar.dev`. Because of this, changes are merged through a pull request rather than
+pushed to `master` directly.
 
-1. Build the site: `pnpm build`
-2. Export additional files: `pnpm export`
-3. Deploy: `pnpm deploy`
+The `pnpm deploy` script is a separate, manual path and is **not** what CI runs:
+`gh-pages -d out -o gh-pages -b master` publishes to the remote named `gh-pages` — the
+separate `naturalclar.github.io` repository — and to the `master` branch there. The two are
+not interchangeable.
 
-The deployment script uses gh-pages to push the `out` directory to the `master` branch.
+Every push also runs `.github/workflows/CI.yml`, which lints, type-checks, and builds.
 
 ## License
 


### PR DESCRIPTION
Closes #51

Documentation only. This is the README counterpart to #47, which fixed the same class of drift in `CLAUDE.md`.

## The three corrections from #51

**1. Framework version**

```diff
-- **Framework**: Next.js 14 with AMP support
+- **Framework**: Next.js 15 with AMP support
```

`package.json` declares `next: ^15.3.4`.

**2. Missing lint scripts**

Adds `pnpm lint` and `pnpm lint:fix`, and lists oxlint in the tech stack — the README did not mention the project had a linter at all.

**3. Deployment section described the wrong process**

The old text presented `pnpm build` → `pnpm export` → `pnpm deploy` as *the* deployment process. It is not: **pushing to `master` deploys**, via `Deploy.yml`.

Rewritten to say so, and to separate out `pnpm deploy` as a manual path that publishes to the `master` branch of the *separate* `naturalclar.github.io` repo. The old single sentence — "uses gh-pages to push the `out` directory to the `master` branch" — read as if the two were the same thing.

Since push-to-`master` deploys, the section also notes that changes land through a pull request, and that CI lints, type-checks, and builds on every push.

## Also refreshed

These had drifted alongside the above, so they are corrected in the same pass rather than left to rot:

- **Prerequisites** listed a bare "Node.js / pnpm". Now names Node 24.x to match CI, and notes pnpm is pinned by `packageManager` so Corepack selects it.
- **Project structure** predated `.oxlintrc.json` and omitted `index.d.ts`, which is where `<amp-img>` is declared for JSX. `extra/` is also described more precisely.

## Verification

Every factual claim was checked against the repo rather than carried over: the `next` version and script names from `package.json`, `node-version` from `CI.yml`, the `packageManager` value, and the existence of the referenced files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_