### PR TITLE
chore: add Google Search Console verification file

### DIFF
--- a/public/google9d8ab29cd5ed907e.html
+++ b/public/google9d8ab29cd5ed907e.html
@@ -1,0 +1,1 @@
+google-site-verification: google9d8ab29cd5ed907e.html


### PR DESCRIPTION
## What

Adds `public/google9d8ab29cd5ed907e.html`, the Google Search Console ownership-verification file for **naturalclar.dev**. Needed to publish the OAuth consent screen for the medley-generator project.

One new file, 53 bytes. No other changes.

## Why this path serves correctly

`public/` maps to the site root — the existing site already relies on this, with `public/static/cat_square.jpg` served as `https://naturalclar.dev/static/cat_square.jpg` (`head/Meta.tsx:17`). So the file lands at:

```
https://naturalclar.dev/google9d8ab29cd5ed907e.html
```

The conditions that commonly break file verification were each checked against this repo:

| Risk | Status |
|---|---|
| Extension-bearing URLs rewritten | `next.config.js` sets only `output: "export"` — no `trailingSlash`, `rewrites` or `redirects` |
| SPA fallback sending all paths to `index.html` | None; static export emits a real `404.html` |
| Jekyll swallowing the file | `extra/.nojekyll` is copied into `out/` by `pnpm export` |

## File integrity

Committed byte-for-byte as issued, verified with `cmp` against the expected content: **53 bytes, no trailing newline, no BOM, no reformatting.**

```
google-site-verification: google9d8ab29cd5ed907e.html
```

**Please do not reformat or delete this file.** Google re-checks periodically, and ownership lapses if it disappears.

## After merge

The push to `master` triggers `Deploy.yml`. Once it finishes, confirm with:

```sh
curl -i https://naturalclar.dev/google9d8ab29cd5ed907e.html
```

## Note on the domain

The original request asked for `https://naturalclar.github.io/<file>`, but this repository does not serve that host — it deploys to the `gh-pages` branch of `Naturalclar/naturalclar.dev` with `CNAME` set to `naturalclar.dev`. The separate `Naturalclar/naturalclar.github.io` repository serves `naturalclar.github.io`, and it also carries a `CNAME` of `naturalclar.dev` (from a 2020 deploy), which makes GitHub Pages redirect that host to this one. `naturalclar.dev` was confirmed as the intended target before this file was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_