### PR TITLE
ci: replace pnpm/action-setup and setup-node with pnpm/setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,20 +7,21 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      node-version: 24.x
+      node-runtime: node@24
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v6
-
-      - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v7
+      # pnpm/setup は pnpm 本体と JS ランタイムの両方を入れるため、
+      # actions/setup-node は不要。install は既定で走るが --frozen-lockfile を
+      # 渡せないので false にし、次のステップで明示的に実行する。
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          node-version: ${{ env.node-version }}
-          cache: 'pnpm'
+          runtime: ${{ env.node-runtime }}
+          cache: true
+          install: false
 
       - name: Install packages
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -12,20 +12,21 @@ jobs:
     if: github.repository == 'Naturalclar/naturalclar.dev'
 
     env:
-      node-version: 24.x
+      node-runtime: node@24
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v6
-
-      - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v7
+      # pnpm/setup は pnpm 本体と JS ランタイムの両方を入れるため、
+      # actions/setup-node は不要。install は既定で走るが --frozen-lockfile を
+      # 渡せないので false にし、あとで明示的に実行する。
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          node-version: ${{ env.node-version }}
-          cache: 'pnpm'
+          runtime: ${{ env.node-runtime }}
+          cache: true
+          install: false
 
       - name: Add origin
         run: git remote add gh-pages https://github.com/Naturalclar/naturalclar.github.io.git
@@ -42,8 +43,10 @@ jobs:
       - name: Prepare Deploy
         run: pnpm export
       - name: Deploy with gh-pages
+        # gh-pages は devDependency なので pnpm exec で解決できる。npx だと
+        # 毎回レジストリから取り直すうえ、npm 自体に依存してしまう。
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npx gh-pages -d out -u "github-actions-bot <support+actions@github.com>"
+          pnpm exec gh-pages -d out -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #58

## What

`pnpm/setup` installs both pnpm and the JS runtime, so the two setup steps collapse into one and `actions/setup-node` goes away.

```diff
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v6
-
-      - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v7
-        with:
-          node-version: ${{ env.node-version }}
-          cache: 'pnpm'
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@v2
+        with:
+          runtime: ${{ env.node-runtime }}
+          cache: true
+          install: false
```

The Node version moves from `node-version: 24.x` to `runtime: node@24`, which is the format the action takes. `pnpm/setup@v2` supports pnpm 11 and newer; `packageManager` pins `pnpm@11.21.0`.

## Resolving the two blockers from #58

#58 flagged two questions that had to be answered before attempting this, since getting either wrong breaks a workflow. Both are settled.

### 1. `--frozen-lockfile`

The `install` input defaults to **true**, but it runs a bare `pnpm install` — the README documents no way to pass extra flags. A plain install in CI would silently accept a drifted lockfile.

Fixed by setting `install: false` and keeping the explicit step:

```yaml
- name: Install packages
  run: pnpm install --frozen-lockfile
```

### 2. `npx` in `Deploy.yml`

The publish step ran `npx gh-pages -d out`, and the README does not state whether the runtime installed by `pnpm runtime set` puts npm/npx on `PATH`. This was the risk that could have broken deployment.

**The question turns out to be moot.** `gh-pages` is already a devDependency (`^5.0.0`), so `pnpm exec` resolves it from `node_modules` — no npx, no npm, no registry fetch:

```diff
-          npx gh-pages -d out -u "github-actions-bot <support+actions@github.com>"
+          pnpm exec gh-pages -d out -u "github-actions-bot <support+actions@github.com>"
```

This is an improvement independent of the migration: the old command re-downloaded `gh-pages` from the registry on every deploy despite it being installed already.

Verified locally against the repo's own dependency tree:

```
$ pnpm exec gh-pages --version
5.0.0
```

## Verification

`pnpm install --frozen-lockfile`, `pnpm lint` and `pnpm type-check` pass locally.

Action behaviour on the runner cannot be exercised locally, so:

- **CI on this PR is the check for `CI.yml`** — a green run confirms `pnpm/setup@v2` resolves pnpm from `packageManager`, installs `node@24`, and that the cache input works.
- **`Deploy.yml` needs a look after merge.** Its publish step only runs on push to `master`, so CI here does not exercise it. I will check that run once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_