### PR TITLE
fix: publish the deploy to the repository that actually serves the site

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -28,12 +28,6 @@ jobs:
           cache: true
           install: false
 
-      - name: Add origin
-        run: git remote add gh-pages https://github.com/Naturalclar/naturalclar.github.io.git
-
-      - name: Echo origin
-        run: git remote -v
-
       - name: Install packages
         run: pnpm install --frozen-lockfile
 
@@ -42,11 +36,20 @@ jobs:
 
       - name: Prepare Deploy
         run: pnpm export
-      - name: Deploy with gh-pages
-        # gh-pages は devDependency なので pnpm exec で解決できる。npx だと
-        # 毎回レジストリから取り直すうえ、npm 自体に依存してしまう。
+
+      # naturalclar.dev を配信しているのは Naturalclar/naturalclar.github.io の
+      # master (ユーザーページ)。このリポジトリの gh-pages ブランチに publish
+      # しても公開サイトには出ないため、別リポジトリを直接指定する。
+      #
+      # secrets.GITHUB_TOKEN は自リポジトリにしか書き込めないので、
+      # naturalclar.github.io への push 権限を持つ PAT を PAGES_DEPLOY_TOKEN
+      # として登録しておくこと。
+      - name: Deploy to naturalclar.github.io
         run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          pnpm exec gh-pages -d out -u "github-actions-bot <support+actions@github.com>"
+          pnpm exec gh-pages \
+            -d out \
+            -b master \
+            -r "https://git:${PAGES_DEPLOY_TOKEN}@github.com/Naturalclar/naturalclar.github.io.git" \
+            -u "github-actions-bot <support+actions@github.com>"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAGES_DEPLOY_TOKEN: ${{ secrets.PAGES_DEPLOY_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,21 @@ site is a single page).
 ## Deployment
 
 **Pushing to `master` deploys to production.** `.github/workflows/Deploy.yml` triggers on
-push to `master`, builds, runs `pnpm export`, then publishes `out/` with `npx gh-pages`.
-It re-points `origin` at the current repo first, so it lands on the `gh-pages` branch of
-`naturalclar.dev`. The workflow is guarded by `if: github.repository ==
-'Naturalclar/naturalclar.dev'` so forks do not deploy.
+push to `master`, builds, runs `pnpm export`, then publishes `out/` with `gh-pages`. The
+workflow is guarded by `if: github.repository == 'Naturalclar/naturalclar.dev'` so forks do
+not deploy.
 
-The `pnpm deploy` script does something different: `gh-pages -d out -o gh-pages -b master`
-targets the remote named `gh-pages` (the separate `naturalclar.github.io` repo) and the
-`master` branch there. Do not assume the two paths are interchangeable.
+**The site is served from a different repository than this one.** `naturalclar.dev` is the
+custom domain of `Naturalclar/naturalclar.github.io` — the user page — so its `master`
+branch is what visitors get, and project pages for the account are served under
+`naturalclar.dev/<repo>/`. Deploy therefore publishes across repositories, which
+`secrets.GITHUB_TOKEN` cannot do: it needs a PAT with push access to
+`naturalclar.github.io`, stored as the `PAGES_DEPLOY_TOKEN` secret. The `pnpm deploy`
+script targets the same place by hand, via a local remote named `gh-pages`.
+
+This repo also has its own stale `gh-pages` branch. Deploy published there from 2024 until
+this was corrected, and none of it ever reached the live site — the branch and its `CNAME`
+are leftovers. Do not treat it as the deployment target.
 
 ## Shipping a change
 
@@ -109,6 +116,9 @@ have already asked you to merge.
 
 - `tsconfig.tsbuildinfo` is **tracked in git**, so `pnpm type-check` and `pnpm build` dirty
   the working tree. Restore it before committing unless the change is intentional.
+- `next-env.d.ts` is tracked too and flips depending on which command ran last: `next dev`
+  writes imports of `./.next/dev/types/*`, `next build` writes `./.next/types/*`. Either
+  type-checks, so restore it rather than committing the churn.
 - **pnpm's version lives in `package.json`'s `packageManager` field**, not in the workflows.
   `pnpm/setup` reads it and neither workflow passes a `version` input, so bump the
   field rather than the YAML. pnpm 11 keeps `lockfileVersion: '9.0'`, so the lockfile does


### PR DESCRIPTION
> [!IMPORTANT]
> **Add the `PAGES_DEPLOY_TOKEN` secret before merging.** Without it the deploy step fails on `master`. Draft until then — see *Before merging* below.

## The bug

`naturalclar.dev` is the custom domain of **`Naturalclar/naturalclar.github.io`** (the user page). Deploy has been publishing to *this* repository's own `gh-pages` branch, which nothing serves.

So every workflow run reported success while the live site stayed frozen on a 2020 build. That is why the site still shows AMP and the Font Awesome Twitter icon after #61, #62 and #63 all "deployed".

Evidence:

| Repository / branch | Content | Last updated |
|---|---|---|
| `naturalclar.dev` @ `gh-pages` (what CI published to) | inline SVG, no JS, no AMP | **2026-08-13** |
| `naturalclar.github.io` @ `master` (what serves the domain) | `amp-runtime`, `amp-img`, `fa fa-twitter` | **2020-10-22** |

Both branches carry a `CNAME` of `naturalclar.dev`, which is what made this easy to miss.

This is not new: the `gh-pages` branch here has **18 commits going back to 2024-05**, none of which ever reached a visitor. It looks to date from the deploy rework in #31–#33.

## The fix

Publish straight to `naturalclar.github.io`'s `master` using `gh-pages`' `-r` flag:

```yaml
- name: Deploy to naturalclar.github.io
  run: |
    pnpm exec gh-pages \
      -d out \
      -b master \
      -r "https://git:${PAGES_DEPLOY_TOKEN}@github.com/Naturalclar/naturalclar.github.io.git" \
      -u "github-actions-bot <support+actions@github.com>"
  env:
    PAGES_DEPLOY_TOKEN: ${{ secrets.PAGES_DEPLOY_TOKEN }}
```

The `Add origin` and `Echo origin` steps are removed. They added a remote named `gh-pages` that the publish command never used — a leftover from the original design, and part of why the target drift went unnoticed.

`extra/CNAME` still ships in `out/`, which is what keeps the custom domain attached on the receiving repository.

## Before merging

This publishes across repositories, and `secrets.GITHUB_TOKEN` is scoped to this one. So:

1. Create a PAT with **push access to `Naturalclar/naturalclar.github.io`** (fine-grained: Contents → Read and write).
2. Add it to this repository as a secret named **`PAGES_DEPLOY_TOKEN`**.
3. Mark this PR ready and merge.

The first deploy after merge will overwrite `naturalclar.github.io`'s `master` with the current build — that is the point, but worth knowing since it replaces 2020 content.

## Worth cleaning up separately

This repository's `gh-pages` branch is now unused, and its `CNAME` makes it a second claimant on `naturalclar.dev`. Disabling Pages on this repository and deleting the branch would remove the ambiguity. I have not touched it — deleting a branch is not something to do unprompted.

## Verification

`pnpm lint`, `pnpm type-check`, `pnpm build` and `pnpm export` all pass, and `out/` contains `CNAME`, both HTML pages with **zero `<script>` tags**, and the Google verification file.

The publish step itself cannot be exercised here — it needs the secret and write access to the other repository. The CI run on this PR does not execute `Deploy.yml` at all, so the first real test is the run on `master` after merge. I will check it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NrHvVEghD4TJDyo8ibxN)_